### PR TITLE
Python 3.4.2 compatibility fix.

### DIFF
--- a/get_win8key.py
+++ b/get_win8key.py
@@ -26,7 +26,7 @@ def EnumAcpiTables():
 def FindAcpiTable(table):
 #checks if specific ACPI table exists and returns True/False
 	tables = EnumAcpiTables()
-	if str(table) in tables:
+	if table in tables:
 		return True
 	else:
 		return False
@@ -48,27 +48,27 @@ def GetAcpiTable(table,TableDwordID):
 	
 def GetWindowsKey():
 	#returns Windows Key as string
-	table="MSDM"
+	table=b"MSDM"
 	TableDwordID=1296323405
 	if FindAcpiTable(table)==True:
 		try:
 			rawtable = GetAcpiTable(table, TableDwordID)
 			#http://msdn.microsoft.com/library/windows/hardware/hh673514
 			#byte offset 36 from beginning = Microsoft 'software licensing data structure' / 36 + 20 bytes offset from beginning = Win Key
-			return str(rawtable[56:len(rawtable)])
+			return rawtable[56:len(rawtable)].decode("utf-8")
 		except:
 			return False
 	else:
-		print "[ERR] - ACPI table " + table + " not found on this system"
+		print("[ERR] - ACPI table " + str(table) + " not found on this system")
 		return False
 	
 try:	
 	WindowsKey=GetWindowsKey()
 	if WindowsKey==False:
-		print "unexpected error"
+		print("unexpected error")
 		exit(1)
 	else:
-		print str(WindowsKey)
+		print(str(WindowsKey))
 except:
-	print "unexpected error"
+	print("unexpected error")
 	exit(1)


### PR DESCRIPTION
This fix worked for me with Python 3.4.2
I have not tested this code with other python versions.

P.S. when I created this pull request I noticed that cpiotr/get_win8key forked from christian-korneck/get_win8key
has also python 3 compatibility fix.