### PR TITLE
Add linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ get_win8key
 
 script to read a preinstalled Windows 8.x OEM license key from a PC's firmware
 
-
 Description
 -------------
 PCs with a preinstalled Windows 8.x OEM version don't seem to ship with any printed license record, CD Key, etc.
@@ -13,16 +12,27 @@ To still be able to backup / inventorize the license key, this script tries to r
 (from ACPI -> MSDM table -> byte offset 56 to end)
 
 
-Usage
+Windows Usage
 -------------
+
 run "get_win8key.exe" or "python get_win8key.py" from a Windows shell.
+
+Linux Usage
+-----------
+
+sudo python get_win8key.py
 
 Requirements
 -------------
--Windows Vista or higher (32 or 64 bit)  
--tested with Python 2.7 and 3.4
+
+Executable:
+* Windows Vista or higher (32 or 64 bit)
+
+Python:
+* Linux or Windows
+* Python 2.7 or 3.4
 
 Files
 -------------
-get_win8key.py..................the script  
-get_win8key.exe.................compiled py2exe  
+get_win8key.py..................the script
+get_win8key.exe.................compiled with py2exe

--- a/acpi.py
+++ b/acpi.py
@@ -1,0 +1,42 @@
+import ctypes
+import ctypes.wintypes
+
+def EnumAcpiTables():
+#returns a list of the names of the ACPI tables on this system
+	FirmwareTableProviderSignature=ctypes.wintypes.DWORD(1094930505)
+	pFirmwareTableBuffer=ctypes.create_string_buffer(0)
+	BufferSize=ctypes.wintypes.DWORD(0)
+	#http://msdn.microsoft.com/en-us/library/windows/desktop/ms724259
+	EnumSystemFirmwareTables=ctypes.WinDLL("Kernel32").EnumSystemFirmwareTables
+	ret=EnumSystemFirmwareTables(FirmwareTableProviderSignature, pFirmwareTableBuffer, BufferSize)
+	pFirmwareTableBuffer=None
+	pFirmwareTableBuffer=ctypes.create_string_buffer(ret)
+	BufferSize.value=ret
+	ret2=EnumSystemFirmwareTables(FirmwareTableProviderSignature, pFirmwareTableBuffer, BufferSize)
+	return [pFirmwareTableBuffer.value[i:i+4] for i in range(0, len(pFirmwareTableBuffer.value), 4)]
+
+def FindAcpiTable(table):
+#checks if specific ACPI table exists and returns True/False
+	tables = EnumAcpiTables()
+	if table in tables:
+		return True
+	else:
+		return False
+
+def GetAcpiTable(table):
+#returns raw contents of ACPI table
+	#http://msdn.microsoft.com/en-us/library/windows/desktop/ms724379x
+	tableID = 0
+	for b in reversed(table):
+		tableID = (tableID << 8) + b
+	GetSystemFirmwareTable=ctypes.WinDLL("Kernel32").GetSystemFirmwareTable
+	FirmwareTableProviderSignature=ctypes.wintypes.DWORD(1094930505)
+	FirmwareTableID=ctypes.wintypes.DWORD(int(tableID))
+	pFirmwareTableBuffer=ctypes.create_string_buffer(0)
+	BufferSize=ctypes.wintypes.DWORD(0)
+	ret = GetSystemFirmwareTable(FirmwareTableProviderSignature, FirmwareTableID, pFirmwareTableBuffer, BufferSize)
+	pFirmwareTableBuffer=None
+	pFirmwareTableBuffer=ctypes.create_string_buffer(ret)
+	BufferSize.value=ret
+	ret2 = GetSystemFirmwareTable(FirmwareTableProviderSignature, FirmwareTableID, pFirmwareTableBuffer, BufferSize)
+	return pFirmwareTableBuffer.raw

--- a/acpi.py
+++ b/acpi.py
@@ -1,19 +1,50 @@
-import ctypes
-import ctypes.wintypes
+import sys
 
-def EnumAcpiTables():
-#returns a list of the names of the ACPI tables on this system
-	FirmwareTableProviderSignature=ctypes.wintypes.DWORD(1094930505)
-	pFirmwareTableBuffer=ctypes.create_string_buffer(0)
-	BufferSize=ctypes.wintypes.DWORD(0)
-	#http://msdn.microsoft.com/en-us/library/windows/desktop/ms724259
-	EnumSystemFirmwareTables=ctypes.WinDLL("Kernel32").EnumSystemFirmwareTables
-	ret=EnumSystemFirmwareTables(FirmwareTableProviderSignature, pFirmwareTableBuffer, BufferSize)
-	pFirmwareTableBuffer=None
-	pFirmwareTableBuffer=ctypes.create_string_buffer(ret)
-	BufferSize.value=ret
-	ret2=EnumSystemFirmwareTables(FirmwareTableProviderSignature, pFirmwareTableBuffer, BufferSize)
-	return [pFirmwareTableBuffer.value[i:i+4] for i in range(0, len(pFirmwareTableBuffer.value), 4)]
+if sys.platform.startswith('win32'):
+	import ctypes
+	import ctypes.wintypes
+
+	def EnumAcpiTables():
+	#returns a list of the names of the ACPI tables on this system
+		FirmwareTableProviderSignature=ctypes.wintypes.DWORD(1094930505)
+		pFirmwareTableBuffer=ctypes.create_string_buffer(0)
+		BufferSize=ctypes.wintypes.DWORD(0)
+		#http://msdn.microsoft.com/en-us/library/windows/desktop/ms724259
+		EnumSystemFirmwareTables=ctypes.WinDLL("Kernel32").EnumSystemFirmwareTables
+		ret=EnumSystemFirmwareTables(FirmwareTableProviderSignature, pFirmwareTableBuffer, BufferSize)
+		pFirmwareTableBuffer=None
+		pFirmwareTableBuffer=ctypes.create_string_buffer(ret)
+		BufferSize.value=ret
+		ret2=EnumSystemFirmwareTables(FirmwareTableProviderSignature, pFirmwareTableBuffer, BufferSize)
+		return [pFirmwareTableBuffer.value[i:i+4] for i in range(0, len(pFirmwareTableBuffer.value), 4)]
+
+	def GetAcpiTable(table):
+	#returns raw contents of ACPI table
+	#http://msdn.microsoft.com/en-us/library/windows/desktop/ms724379x
+		tableID = 0
+		for b in reversed(table):
+			tableID = (tableID << 8) + b
+		GetSystemFirmwareTable=ctypes.WinDLL("Kernel32").GetSystemFirmwareTable
+		FirmwareTableProviderSignature=ctypes.wintypes.DWORD(1094930505)
+		FirmwareTableID=ctypes.wintypes.DWORD(int(tableID))
+		pFirmwareTableBuffer=ctypes.create_string_buffer(0)
+		BufferSize=ctypes.wintypes.DWORD(0)
+		ret = GetSystemFirmwareTable(FirmwareTableProviderSignature, FirmwareTableID, pFirmwareTableBuffer, BufferSize)
+		pFirmwareTableBuffer=None
+		pFirmwareTableBuffer=ctypes.create_string_buffer(ret)
+		BufferSize.value=ret
+		ret2 = GetSystemFirmwareTable(FirmwareTableProviderSignature, FirmwareTableID, pFirmwareTableBuffer, BufferSize)
+		return pFirmwareTableBuffer.raw
+elif sys.platform.startswith('linux'):
+	import os
+	TABLE_ROOT = b'/sys/firmware/acpi/tables'
+	def EnumAcpiTables():
+		return os.listdir(TABLE_ROOT)
+	def GetAcpiTable(table):
+		with open(os.path.join(TABLE_ROOT, table), 'rb') as o:
+			return o.read()
+else:
+	raise NotImplementedError('acpi support only implemented for linux and win32')
 
 def FindAcpiTable(table):
 #checks if specific ACPI table exists and returns True/False
@@ -22,21 +53,3 @@ def FindAcpiTable(table):
 		return True
 	else:
 		return False
-
-def GetAcpiTable(table):
-#returns raw contents of ACPI table
-	#http://msdn.microsoft.com/en-us/library/windows/desktop/ms724379x
-	tableID = 0
-	for b in reversed(table):
-		tableID = (tableID << 8) + b
-	GetSystemFirmwareTable=ctypes.WinDLL("Kernel32").GetSystemFirmwareTable
-	FirmwareTableProviderSignature=ctypes.wintypes.DWORD(1094930505)
-	FirmwareTableID=ctypes.wintypes.DWORD(int(tableID))
-	pFirmwareTableBuffer=ctypes.create_string_buffer(0)
-	BufferSize=ctypes.wintypes.DWORD(0)
-	ret = GetSystemFirmwareTable(FirmwareTableProviderSignature, FirmwareTableID, pFirmwareTableBuffer, BufferSize)
-	pFirmwareTableBuffer=None
-	pFirmwareTableBuffer=ctypes.create_string_buffer(ret)
-	BufferSize.value=ret
-	ret2 = GetSystemFirmwareTable(FirmwareTableProviderSignature, FirmwareTableID, pFirmwareTableBuffer, BufferSize)
-	return pFirmwareTableBuffer.raw

--- a/get_win8key.py
+++ b/get_win8key.py
@@ -1,6 +1,5 @@
 import sys
-import ctypes
-import ctypes.wintypes
+import acpi
 
 #####################################################
 #script to query windows 8.x OEM key from PC firmware
@@ -8,52 +7,13 @@ import ctypes.wintypes
 #ck, 03-Jan-2014 (christian@korneck.de)
 #####################################################
 
-def EnumAcpiTables():
-#returns a list of the names of the ACPI tables on this system
-	FirmwareTableProviderSignature=ctypes.wintypes.DWORD(1094930505)
-	pFirmwareTableBuffer=ctypes.create_string_buffer(0)
-	BufferSize=ctypes.wintypes.DWORD(0)
-	#http://msdn.microsoft.com/en-us/library/windows/desktop/ms724259
-	EnumSystemFirmwareTables=ctypes.WinDLL("Kernel32").EnumSystemFirmwareTables
-	ret=EnumSystemFirmwareTables(FirmwareTableProviderSignature, pFirmwareTableBuffer, BufferSize)
-	pFirmwareTableBuffer=None
-	pFirmwareTableBuffer=ctypes.create_string_buffer(ret)
-	BufferSize.value=ret
-	ret2=EnumSystemFirmwareTables(FirmwareTableProviderSignature, pFirmwareTableBuffer, BufferSize)
-	return [pFirmwareTableBuffer.value[i:i+4] for i in range(0, len(pFirmwareTableBuffer.value), 4)]
-
-def FindAcpiTable(table):
-#checks if specific ACPI table exists and returns True/False
-	tables = EnumAcpiTables()
-	if table in tables:
-		return True
-	else:
-		return False
-
-def GetAcpiTable(table):
-#returns raw contents of ACPI table
-	#http://msdn.microsoft.com/en-us/library/windows/desktop/ms724379x
-	tableID = 0
-	for b in reversed(table):
-		tableID = (tableID << 8) + b
-	GetSystemFirmwareTable=ctypes.WinDLL("Kernel32").GetSystemFirmwareTable
-	FirmwareTableProviderSignature=ctypes.wintypes.DWORD(1094930505)
-	FirmwareTableID=ctypes.wintypes.DWORD(int(tableID))
-	pFirmwareTableBuffer=ctypes.create_string_buffer(0)
-	BufferSize=ctypes.wintypes.DWORD(0)
-	ret = GetSystemFirmwareTable(FirmwareTableProviderSignature, FirmwareTableID, pFirmwareTableBuffer, BufferSize)
-	pFirmwareTableBuffer=None
-	pFirmwareTableBuffer=ctypes.create_string_buffer(ret)
-	BufferSize.value=ret
-	ret2 = GetSystemFirmwareTable(FirmwareTableProviderSignature, FirmwareTableID, pFirmwareTableBuffer, BufferSize)
-	return pFirmwareTableBuffer.raw
 
 def GetWindowsKey():
 	#returns Windows Key as string
 	table=b"MSDM"
-	if FindAcpiTable(table)==True:
+	if acpi.FindAcpiTable(table)==True:
 		try:
-			rawtable = GetAcpiTable(table)
+			rawtable = acpi.GetAcpiTable(table)
 			#http://msdn.microsoft.com/library/windows/hardware/hh673514
 			#byte offset 36 from beginning = Microsoft 'software licensing data structure' / 36 + 20 bytes offset from beginning = Win Key
 			return rawtable[56:len(rawtable)].decode("utf-8")

--- a/get_win8key.py
+++ b/get_win8key.py
@@ -46,7 +46,7 @@ def GetAcpiTable(table,TableDwordID):
 	BufferSize.value=ret
 	ret2 = GetSystemFirmwareTable(FirmwareTableProviderSignature, FirmwareTableID, pFirmwareTableBuffer, BufferSize)
 	return pFirmwareTableBuffer.raw
-	
+
 def GetWindowsKey():
 	#returns Windows Key as string
 	table=b"MSDM"
@@ -62,8 +62,8 @@ def GetWindowsKey():
 	else:
 		print("[ERR] - ACPI table " + str(table) + " not found on this system")
 		return False
-	
-try:	
+
+try:
 	WindowsKey=GetWindowsKey()
 	if WindowsKey==False:
 		print("unexpected error")


### PR DESCRIPTION
A couple cleanup commits followed by moving acpi functions into a module and then the small addition needed to add Linux support.  Exe compiled on Windows 7 32-bit -- tested on Windows 8 64-bit and Arch Linux 64-bit.
